### PR TITLE
Use copy of container image from GitHub Container Registry

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -58,7 +58,7 @@ process {
         maxRetries    = 2
     }
     withLabel:dcqc {
-        container   = 'sagebionetworks/dcqc:latest'
+        container   = 'ghcr.io/sage-bionetworks-workflows/py-dcqc:latest'
         secret      = [
             'SYNAPSE_AUTH_TOKEN'
         ]


### PR DESCRIPTION
This is a short-term fix to the Docker Hub rate limits that we easily run into due to our current infrastructure. 