### PR TITLE
[ORCA-179, ORCA-180] Add params for `required_tests` & `skipped_tests`

### DIFF
--- a/conf/dcqc.config
+++ b/conf/dcqc.config
@@ -1,8 +1,0 @@
-process {
-    withName: '.*:CREATE_TESTS' {
-        ext.args = [
-            params.required_tests   ? params.required_tests.split(",").collect {"--required_tests $it"}.join(" ")​  : "",
-            params.skipped_tests    ? params.skipped_tests.split(",").collect {"--skipped_tests $it"}.join(" ")​    : "",
-        ].join(" ").trim()
-    }
-}

--- a/conf/dcqc.config
+++ b/conf/dcqc.config
@@ -1,0 +1,8 @@
+process {
+    withName: '.*:CREATE_TESTS' {
+        ext.args = [
+            params.required_tests   ? params.required_tests.split(",").collect {"--required_tests $it"}.join(" ")​  : "",
+            params.skipped_tests    ? params.skipped_tests.split(",").collect {"--skipped_tests $it"}.join(" ")​    : "",
+        ].join(" ").trim()
+    }
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,6 +18,13 @@ process {
     //     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     // ]
 
+    withName: '.*:CREATE_TESTS' {
+        ext.args = [
+            params.required_tests   ? params.required_tests.split(",").collect {"--required-tests $it"}.join(" ")   : "",
+            params.skipped_tests    ? params.skipped_tests.split(",").collect {"--skipped-tests $it"}.join(" ")     : ""
+        ].join(" ").trim()
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,7 +18,7 @@ process {
     //     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     // ]
 
-    withName: '.*:CREATE_TESTS' {
+    withName: '.*:(CREATE_TESTS|CREATE_SUITE)' {
         ext.args = [
             params.required_tests   ? params.required_tests.split(",").collect {"--required-tests $it"}.join(" ")   : "",
             params.skipped_tests    ? params.skipped_tests.split(",").collect {"--skipped-tests $it"}.join(" ")     : ""

--- a/conf/test.config
+++ b/conf/test.config
@@ -21,5 +21,7 @@ params {
 
     // Input data
     input = "${projectDir}/testdata/input_txt.csv"
+    required_tests = "LibTiffInfoTest,BioFormatsInfoTest,OmeXmlSchemaTest"
+    skipped_tests = "FileExtensionTest,Md5ChecksumTest"
 
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,4 +16,6 @@ params {
 
     // Input data for full size test
     input = "${projectDir}/testdata/input_full.csv"
+    required_tests = "LibTiffInfoTest,BioFormatsInfoTest,OmeXmlSchemaTest"
+    skipped_tests = "FileExtensionTest,Md5ChecksumTest"
 }

--- a/modules/local/create_suite.nf
+++ b/modules/local/create_suite.nf
@@ -13,7 +13,8 @@ process CREATE_SUITE {
     task.ext.when == null || task.ext.when
 
     script:
+    def args = task.ext.args ?: ''
     """
-    dcqc create-suite "${target_id}.suite.json" *.json
+    dcqc create-suite ${args} "${target_id}.suite.json" *.json
     """
 }

--- a/modules/local/create_tests.nf
+++ b/modules/local/create_tests.nf
@@ -13,7 +13,8 @@ process CREATE_TESTS {
     task.ext.when == null || task.ext.when
 
     script:
+    def args = task.ext.args ?: ''
     """
-    dcqc create-tests "${target_json}" tests/
+    dcqc create-tests ${args} "${target_json}" tests/
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,8 +11,8 @@ params {
 
     // Input options
     input                      = null
-    required_test              = null
-    skipped_test               = null
+    required_tests             = null
+    skipped_tests              = null
 
     // Boilerplate options
     outdir                     = "results"
@@ -47,9 +47,6 @@ params {
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
-
-// Load dcqc.config for DCQC-specific configuration
-includeConfig 'conf/dcqc.config'
 
 // Load nf-core custom profiles from different Institutions
 try {

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,8 @@ params {
 
     // Input options
     input                      = null
+    required_test              = null
+    skipped_test               = null
 
     // Boilerplate options
     outdir                     = "results"
@@ -45,6 +47,9 @@ params {
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
+
+// Load dcqc.config for DCQC-specific configuration
+includeConfig 'conf/dcqc.config'
 
 // Load nf-core custom profiles from different Institutions
 try {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,6 +22,18 @@
                     "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.",
                     "fa_icon": "fas fa-file-csv"
                 },
+                "required_tests": {
+                    "type": "string",
+                    "fa_icon": "fas fa-plus-circle",
+                    "description": "Comma-separated list of tests that are required for a file to pass quality control (QC). Consult the dcqc Python package documentation for information on the default behavior since it is subject to change.",
+                    "pattern": "^([A-z0-9]+,)*[A-z0-9]+$"
+                },
+                "skipped_tests": {
+                    "type": "string",
+                    "fa_icon": "fas fa-minus-circle",
+                    "description": "Comma-separated list of tests that should be skipped for all files. Consult the dcqc Python package documentation for information on the default behavior since it is subject to change.",
+                    "pattern": "^([A-z0-9]+,)*[A-z0-9]+$"
+                },
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",


### PR DESCRIPTION
The `create_tests` CLI command in `py-dcqc` already has support for specifying required and skipped tests ([source](https://github.com/Sage-Bionetworks-Workflows/py-dcqc/blob/eff93a22cdb29f0ef229d9e5ebf07f26dd8eec77/src/dcqc/main.py#L88-L89)). This PR exposes these CLI arguments as Nextflow parameters. 

I'm marking this as a draft PR until I can test that this works as expected. 