### PR TITLE
[ORCA-175] Adds functionality to update input CSV with DCQC status

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -40,4 +40,11 @@ process {
         ]
     }
 
+    withName: UPDATE_INPUT {
+        publishDir = [
+            path: { "${params.outdir}/" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,6 +22,5 @@ params {
     // Input data
     input = "${projectDir}/testdata/input_txt.csv"
     required_tests = "LibTiffInfoTest,BioFormatsInfoTest,OmeXmlSchemaTest"
-    skipped_tests = "FileExtensionTest,Md5ChecksumTest"
 
 }

--- a/modules/local/update_input.nf
+++ b/modules/local/update_input.nf
@@ -1,0 +1,19 @@
+process UPDATE_INPUT {
+    label 'process_single'
+    label 'dcqc'
+
+    input:
+    path suites_file
+    path input_csv
+
+    output:
+    path "output.csv"
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    dcqc update-csv ${suites_file} ${input_csv} "output.csv"
+    """
+}

--- a/subworkflows/local/prepare_reports.nf
+++ b/subworkflows/local/prepare_reports.nf
@@ -1,9 +1,11 @@
 include { CREATE_SUITE } from '../../modules/local/create_suite'
 include { COMBINE_SUITES } from '../../modules/local/combine_suites'
+include { UPDATE_INPUT } from '../../modules/local/update_input'
 
 workflow PREPARE_REPORTS {
     take:
     ch_tests_computed  // channel: [ val(target_id), path(result_json) ]
+    ch_input_csv  // channel: path(input_csv)
 
     main:
     ch_tests_by_target = ch_tests_computed.groupTuple()
@@ -14,6 +16,8 @@ workflow PREPARE_REPORTS {
 
     ch_summary_report = COMBINE_SUITES(ch_suites_collected)
 
+    ch_output_csv = UPDATE_INPUT(ch_summary_report, ch_input_csv)
+
     emit:
-    summary = ch_summary_report  // channel: path(summary_json)
+    summary = ch_summary_report  // channel: path(summary_json) 
 }

--- a/testdata/input_txt.csv
+++ b/testdata/input_txt.csv
@@ -1,5 +1,5 @@
 url,file_type,md5_checksum
 syn://syn41864974,TXT,38b86a456d1f441008986c6f798d5ef9
-syn://syn41864977,TXT,a542e9b744bedcfd874129ab0f98c4ff
+syn://syn41864977,TXT,make-status-amber
 syn://syn43716055,TIFF,38b86a456d1f441008986c6f798d5ef9
 syn://syn43716711,TIFF,a542e9b744bedcfd874129ab0f98c4ff

--- a/tower.yml
+++ b/tower.yml
@@ -1,3 +1,3 @@
 reports:
-  "{params.outdir}/output.csv":
+  "${params.outdir}/output.csv":
     display: "DCQC Output CSV file"

--- a/tower.yml
+++ b/tower.yml
@@ -1,3 +1,3 @@
 reports:
-  "${params.outdir}/output.csv":
+  "**/output.csv":
     display: "DCQC Output CSV file"

--- a/tower.yml
+++ b/tower.yml
@@ -1,0 +1,3 @@
+reports:
+  "{params.outdir}/output.csv":
+    display: "DCQC Output CSV file"

--- a/workflows/dcqc.nf
+++ b/workflows/dcqc.nf
@@ -73,7 +73,7 @@ workflow DCQC {
 
     ch_tests_computed = INTERNAL_TESTS.out.mix(EXTERNAL_TESTS.out)
 
-    ch_summary = PREPARE_REPORTS(ch_tests_computed)
+    ch_summary = PREPARE_REPORTS(ch_tests_computed, ch_input)
 
 }
 


### PR DESCRIPTION
This PR adds the `UPDATE_INPUT` process within the `PREPARE_REPORTS` subworkflow. It takes the result of `COMBINE_SUITES`, and the initial input CSV file, and produces an updated CSV with the `dcqc_status` column added to give a human-readable summary of the DCQC run on each file. The updated CSV file, along with the `suite.json` summary file can be found in `params.outdir` when the workflow has completed its run. I have also updated the test configuration and its corresponding input file to produce one expected `AMBER` status.

Another addition is the configuration of `tower.yml` which displays the output CSV file as a report in the Tower UI. I was able to get the report to work ([example](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-project/watch/1IXG4LtBQSESAM)).

These changes have now been tested both locally and on [Tower](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-project/watch/3ZxipMjbLI60tq). Both test runs ran as expected with the same results each run.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
