### PR TITLE
Add synapse secret to local config

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -2,5 +2,8 @@ process {
     withLabel:dcqc {
         // Default container name when running `src/docker/build.sh` in py-dcqc
         container   = 'dcqc'
+        secret      = [
+            'SYNAPSE_AUTH_TOKEN'
+        ]
     }
 }


### PR DESCRIPTION
# **Problem:**
When using the `local.config` when running nf-dcqc locally the Synapse token isn't getting propogated to the local py-dcqc image. This doesn't happen when the `local.config` isn't used.

# **Solution:**
Add the `secret  = ['SYNAPSE_AUTH_TOKEN']` parameter to the local config. This allows the user to set the secret by doing:
`nextflow secrets set SYNAPSE_AUTH_TOKEN xxx`

